### PR TITLE
Cleaned up video preview

### DIFF
--- a/simple.xml
+++ b/simple.xml
@@ -25,8 +25,8 @@ license:		creative commons CC-BY-NC-SA
 
 
 			<video name="md_video">
-				<pos>0.025 0.22</pos>
-				<maxSize>0.124 0.301</maxSize>
+				<pos>0.02 0.22</pos>
+				<maxSize>0.290 0.352</maxSize>
 				<origin>0 0</origin>
 				<delay>0.2</delay>
 				<default></default>
@@ -136,7 +136,7 @@ license:		creative commons CC-BY-NC-SA
 
 	<view name="detailed">
 	</view>
-
+	
 	<view name="video">
 	
 <!-- <measuring rectangle 
@@ -148,94 +148,94 @@ license:		creative commons CC-BY-NC-SA
 			<color>ff00ff</color>
 		</image> 
 -->
-
-		<image name="md_image">
-			<pos>0.025 0.22</pos>
-<!-- 			<size>0.125 0.301</size>
- -->			<maxSize>0.125 0.301</maxSize>
+<!-- 
+			<image name="md_image">
+			<pos>0.225 0.41</pos>
+			<size>0.125 0.301</size>
+			<maxSize>0.07 0.17</maxSize>
 			<origin>0 0</origin>
 		</image>
-		
+	 -->	
 		<text name="md_lbl_rating">
-			<pos>0.177 0.21</pos>
+			<pos>0.32 0.21</pos>
 		</text>
 		
 		<text name="md_lbl_releasedate">
-			<pos>0.177 0.25</pos>
+			<pos>0.32 0.25</pos>
 		</text>
 		
 		<text name="md_lbl_developer">
-			<pos>0.177 0.29</pos>
+			<pos>0.32 0.29</pos>
 			<size>0.133 0.04</size>
 		</text>
 
 		<text name="md_lbl_publisher">
-			<pos>0.177 0.33</pos>
+			<pos>0.32 0.33</pos>
 			<size>0.133 0.04</size>
 		</text>
 		
 		<text name="md_lbl_genre">
-			<pos>0.177 0.37</pos>
+			<pos>0.32 0.37</pos>
 		</text>
 		
 		<text name="md_lbl_players">
-			<pos>0.177 0.41</pos>
+			<pos>0.32 0.41</pos>
 		</text>
 
 		<text name="md_lbl_lastplayed">
-			<pos>0.177 0.45</pos>
+			<pos>0.32 0.45</pos>
 		</text>
 
 		<text name="md_lbl_playcount">
-			<pos>0.177 0.49</pos>
+			<pos>0.32 0.49</pos>
 		</text>
 		
 		<text name="md_playcount">
-			<pos>0.31 0.49</pos>
+			<pos>0.448 0.49</pos>
 		</text>
 
 		<datetime name="md_lastplayed">
-			<pos>0.31 0.45</pos>
+			<pos>0.448 0.45</pos>
 		</datetime>
 		
 		<text name="md_players">
-			<pos>0.31 0.41</pos>
+			<pos>0.448 0.41</pos>
 		</text>
 		
 		<text name="md_genre">
-			<pos>0.31 0.37</pos>
-			<size>0.24 0.04</size>
+			<pos>0.448 0.37</pos>
+			<size>0.167 0.04</size>
 		</text>
 
 		<text name="md_publisher">
-			<pos>0.31 0.33</pos>
-			<size>0.24 0.04</size>
+			<pos>0.448 0.33</pos>
+			<size>0.167 0.04</size>
 		</text>
 		
 		<text name="md_developer">
-			<pos>0.31 0.29</pos>
-			<size>0.24 0.04</size>
+			<pos>0.448 0.29</pos>
+			<size>0.167 0.04</size>
 		</text>
 		
 		<datetime name="md_releasedate">
-			<pos>0.31 0.25</pos>
+			<pos>0.448 0.25</pos>
 		</datetime>
 		
 		<rating name="md_rating">
-			<pos>0.31 0.216</pos>
+			<pos>0.448 0.216</pos>
 			<size>0.028 0.028</size>
-			<filledPath>./../art/star_filled_spacing.svg</filledPath>
-			<unfilledPath>./../art/star_hollow_3_spacing.svg</unfilledPath>
+			<filledPath>./art/star_filled_spacing.svg</filledPath>
+			<unfilledPath>./art/star_hollow_3_spacing.svg</unfilledPath>
 		</rating>
 		
 		<text name="md_description">
-			<size>0.52 0.3</size>
-			<pos>0.025 0.577</pos>
+			<size>0.59 0.29</size>
+			<pos>0.025 0.61</pos>
 		</text>
 		
 		<textlist name="gamelist">
-			<pos>0.615 0.22</pos>
-			<size>0.359 0.68</size>
+			<pos>0.635 0.22</pos>
+			<size>0.319 0.68</size>
 			<alignment>left</alignment>
 			<horizontalMargin>0.01</horizontalMargin>
 		</textlist>


### PR DESCRIPTION
Altered the positions and sizes of the different elements in the video view to correctly show video snaps. Removed underlaying boxart when a video snap is present. Boxart will show whenever no video snap is present though.